### PR TITLE
Constrain the type of functions in ValidateFunction

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,7 +16,7 @@ declare module "express-json-validator-middleware" {
 		| JSONSchema7;
 
 	export type ValidateFunction =
-		| (req: Request) => AllowedSchema
+		| ((req: Request) => AllowedSchema)
 		| AllowedSchema;
 
 	export class Validator {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,7 +13,7 @@ declare module "express-json-validator-middleware" {
 	type AllowedSchema =
 		| JSONSchema4
 		| JSONSchema6
-		| JSONSchema7
+		| JSONSchema7;
 
 	export type ValidateFunction =
 		| (req: Request) => AllowedSchema

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,4 @@
+import { Request } from "express";
 import { RequestHandler } from "express-serve-static-core";
 import { JSONSchema4, JSONSchema6, JSONSchema7 } from "json-schema";
 import { ErrorObject, Options as AjvOptions } from "ajv";
@@ -9,11 +10,14 @@ declare module "express-json-validator-middleware" {
 		[K in OptionKey]?: T;
 	};
 
-	export type ValidateFunction =
-		| Function
+	type AllowedSchema =
 		| JSONSchema4
 		| JSONSchema6
-		| JSONSchema7;
+		| JSONSchema7
+
+	export type ValidateFunction =
+		| (req: Request) => AllowedSchema
+		| AllowedSchema;
 
 	export class Validator {
 		constructor(options: AjvOptions);


### PR DESCRIPTION
Allowing arbitrary, untyped functions means that a middleware invocation that returns an invalid schema will compile without errors, but may crash or misbehave aggressively at runtime when AJV rejects the invalid schema.