### PR TITLE
Update CI workflow to run for default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ $default-branch ]
   pull_request:
-    branches: [ master ]
+    branches: [ $default-branch ]
 
 jobs:
   build:


### PR DESCRIPTION
This uses a GitHub Actions macro (`$default-branch`).

Fixes #63.
