### PR TITLE
Drop support for Node.js 8 and add support for 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 15.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Node.js 8 has been end-of-life since December 31st 2019.

Node.js 16 is due to go in to active LTS (Long-term Support) from late October 26th 2021.
