### PR TITLE
Restrict published files for this package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-# TravisCI configuration file
-.travis.yml	
-
-# ESLint configuration
-.eslintrc.json
-
-# No tests in published code
-test

--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
 		"prepublish": "npm run lint && npm run test"
 	},
 	"types": "src/index.d.ts",
-	"mocha": {
-		"timeout": 15000
-	},
 	"devDependencies": {
 		"codecov": "^3.8.1",
 		"eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -56,5 +56,9 @@
 	"lint-staged": {
 		"*.js": "eslint --cache --fix",
 		"*.{js,css,md}": "prettier --write"
-	}
+	},
+	"files": [
+		"src/*.js",
+		"src/*.d.ts"
+	]
 }


### PR DESCRIPTION
An allow list (as provided by the `files` field in `package.json`) is more effective than a deny list (as provided by `.npmignore`).

By using an allow list  we can ensure that random files don't accidentally get published (as happened with the v2.2.0 release).

Fixes #92.