### PR TITLE
Fix Ajv import

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,7 @@
 import { Request } from "express";
 import { RequestHandler } from "express-serve-static-core";
 import { JSONSchema4, JSONSchema6, JSONSchema7 } from "json-schema";
-import { Ajv, ErrorObject, Options as AjvOptions } from "ajv";
+import Ajv, { ErrorObject, Options as AjvOptions } from "ajv";
 
 declare module "express-json-validator-middleware" {
 	type OptionKey = "body" | "params" | "query";


### PR DESCRIPTION
Thanks for this package! I had trouble finding something to help me validate and OpenApi Doc with nested discriminators but I managed to get this working for my needs and its great! 

Opening this PR to fix this issue that cropped up for me, ajv is the default export:

```
node_modules/express-json-validator-middleware/src/index.d.ts:4:10 - error TS2614: Module '"ajv"' has no exported member 'Ajv'. Did you mean to use 'import Ajv from "ajv"' instead?

4 import { Ajv, ErrorObject, Options as AjvOptions } from "ajv";
           ~~~


Found 1 error.
```