### PR TITLE
Add type checking of TypeScript declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
 	},
 	"homepage": "https://github.com/simonplend/express-json-validator-middleware#readme",
 	"scripts": {
-		"test": "tap",
+		"test": "npm run test:unit && npm run test:types",
+		"test:unit": "tap",
+		"test:types": "tsc --noEmit --strict src/index.d.ts",
 		"lint": "eslint \"src/*.js\" --fix",
 		"prepush": "npm run lint && npm run test",
 		"prepublish": "npm run lint && npm run test"
@@ -37,7 +39,8 @@
 		"mocha": "^7.1.1",
 		"prettier": "^1.19.1",
 		"simple-get": "^4.0.0",
-		"tap": "^15.1.5"
+		"tap": "^15.1.5",
+		"typescript": "^4.6.4"
 	},
 	"dependencies": {
 		"@types/express": "^4.17.3",


### PR DESCRIPTION
`npm test` now runs unit tests and type checking of the TypeScript declarations.

This should help avoid issues like #110.