### PR TITLE
Allow custom Ajv instance (closes #115)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
 		"eslint:recommended"
 	],
 	"parserOptions": {
-		"ecmaVersion": 2017,
+		"ecmaVersion": 2020,
 		"node": true
 	},
 	"rules": {

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ const addressSchema = {
 
 /**
  * Initialize a `Validator` instance, optionally passing in
- * an Ajv options object.
+ * an Ajv options object or an Ajv instance.
  *
  * @see https://github.com/ajv-validator/ajv/tree/v6#options
  */

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	"scripts": {
 		"test": "npm run test:unit && npm run test:types",
 		"test:unit": "tap",
-		"test:types": "tsc --noEmit --strict src/index.d.ts",
+		"test:types": "tsc --noEmit --strict --target ES2018 --moduleResolution node --resolveJsonModule src/index.d.ts",
 		"lint": "eslint \"src/*.js\" --fix",
 		"prepush": "npm run lint && npm run test",
 		"prepublish": "npm run lint && npm run test"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,8 @@
 import { Request } from "express";
 import { RequestHandler } from "express-serve-static-core";
 import { JSONSchema4, JSONSchema6, JSONSchema7 } from "json-schema";
-import Ajv, { ErrorObject, Options as AjvOptions } from "ajv";
+import { ErrorObject, Options as AjvOptions } from "ajv";
+import AjvCore from "ajv/lib/core";
 
 declare module "express-json-validator-middleware" {
 	type OptionKey = "body" | "params" | "query";
@@ -20,9 +21,9 @@ declare module "express-json-validator-middleware" {
 		| AllowedSchema;
 
 	export class Validator {
-		constructor(options: AjvOptions);
+		constructor(options: AjvOptions | AjvCore);
 
-		ajv: Ajv;
+		ajv: AjvCore;
 
 		validate(rules: List<ValidateFunction>): RequestHandler;
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,12 @@ const Ajv = require("ajv");
  */
 class Validator {
 	constructor(ajvOptions) {
-		this.ajv = new Ajv(ajvOptions);
+		if (typeof ajvOptions?.compile === "function") {
+			this.ajv = ajvOptions;
+		} else {
+			this.ajv = new Ajv(ajvOptions);
+		}
+
 		this.validate = this.validate.bind(this);
 	}
 

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -1,8 +1,13 @@
 const { test } = require("tap");
 const Ajv = require("ajv");
+const Ajv2019 = require("ajv/dist/2019");
 
 const { Validator } = require("../src");
 
 test("Validator instance", async t => {
 	t.type(new Validator().ajv, Ajv, " property `ajv` should be an Ajv instance");
+});
+
+test("Validator instance w/ custom AJV instance", async t => {
+	t.type(new Validator(new Ajv2019()).ajv, Ajv2019, " property `ajv` should be an Ajv2019 instance");
 });


### PR DESCRIPTION
Previously, `Validator` would only take an object containing Ajv options. With this PR, we've added the possibility to pass a custom Ajv instance instead, for example one of the 2019-09 draft version[1]:

```js
const Ajv2019 = require('ajv/dist/2019')
const ajv = new Ajv2019()

const validator = new Validator(ajv)
```

[1] https://ajv.js.org/json-schema.html#draft-2019-09