### PR TITLE
fix: issue with example URL query string in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ app.post(
 ```
 
 A valid request must now include a token URL query. Example valid URL:
-`/street/?uuid=af3996d0-0e8b-4165-ae97-fdc0823be417`
+`/street/?token=af3996d0-0e8b-4165-ae97-fdc0823be417`
 
 ## Using dynamic schema
 


### PR DESCRIPTION
Line 214 exemplifies the use of validating query string URL parameters using the library. However, the example was using the wrong query string parameter - "uuid", whereas the preceding JSON schema (tokenSchema) starting from line 188, was checking for a property called "token".